### PR TITLE
On save, esc_url for wpsl_website, esc_attr for everything else

### DIFF
--- a/app/WPData/MetaFields.php
+++ b/app/WPData/MetaFields.php
@@ -92,7 +92,10 @@ class MetaFields {
 			// Save Custom Fields
 			foreach ( $this->fields as $key => $field )
 			{
-				if ( isset($_POST[$field]) && $_POST[$field] !== "" ) update_post_meta( $post_id, $field, esc_attr( $_POST[$field] ) );
+				if ( isset($_POST[$field]) && $_POST[$field] !== "" ) :
+					if ( $field == 'wpsl_website' ) update_post_meta( $post_id, $field, esc_url( $_POST[$field] ) );
+					else update_post_meta( $post_id, $field, esc_attr( $_POST[$field] ) );
+				endif;
 			}
 		endif;
 	} 


### PR DESCRIPTION
Was running into trouble with admin users not adding the full website url and not being able to esc_url from the "Results Display" settings. This change uses esc_url for wpsl_website and keeps esc_attr for everything else.