### PR TITLE
Reset postdata from style query before return (Fixes #58, #43)

### DIFF
--- a/app/Repositories/MapStyles.php
+++ b/app/Repositories/MapStyles.php
@@ -50,8 +50,10 @@ class MapStyles
 			'posts_per_page' => 1
 		));
 		if ( $style_query->have_posts() ) : while ( $style_query->have_posts() ) : $style_query->the_post();
-			return json_decode(get_the_content());
-		endwhile; endif; wp_reset_postdata();
+			$style_content = json_decode(get_the_content());
+		endwhile; endif;
+		wp_reset_postdata();
+		return $style_content;
 	}
 
 }


### PR DESCRIPTION
I encountered the issue with the custom style option interfering with the global WP query (#58 & #43). This resolved the issue for me. (Previously, `wp_reset_postdata()` would not be called if a style was selected since it appears after the return statement.)