### PR TITLE
Fixes #71 : remove break for PHP7 compatibility

### DIFF
--- a/app/Services/Import/CSV/CSVImport.php
+++ b/app/Services/Import/CSV/CSVImport.php
@@ -101,7 +101,6 @@ class CSVImport
 		
 		if ( !$this->rows ) {
 			throw new \SimpleLocator\Services\Import\Exceptions\ImportCompleteException;
-			break;
 		}
 
 		$this->setRecordNumbers();

--- a/app/Services/Import/GoogleMapGeocode.php
+++ b/app/Services/Import/GoogleMapGeocode.php
@@ -45,12 +45,10 @@ class GoogleMapGeocode
 
 		if ( $response_status == 'OVER_QUERY_LIMIT' ){
 			throw new GoogleQueryLimitException(__('Your API limit has been reached. Try again in 24 hours.', 'wpsimplelocator'));
-			break;
 		}
 
 		if ( $response_status == 'REQUEST_DENIED' ){
 			throw new GoogleRequestDeniedException(__('Google Maps Error', 'wpsimplelocator') . ': ' . $json['error_message']);
-			break;
 		}
 
 		if ( $response_status !== 'OK' ) {

--- a/app/Services/Import/Listeners/GetCSVRow.php
+++ b/app/Services/Import/Listeners/GetCSVRow.php
@@ -30,7 +30,6 @@ class GetCSVRow extends ImportAJAXListenerBase
 			$columns = $this->row->getRow($row);
 		} catch ( \Exception $e ){
 			$this->error($e->getMessage);
-			break;
 		}
 
 		$this->respond(array('status'=>'success', 'columns' => $columns, 'row_count' => $this->totalRowCount()));

--- a/app/Services/LocationSearch/LocationSearchValidator.php
+++ b/app/Services/LocationSearch/LocationSearchValidator.php
@@ -10,7 +10,6 @@ class LocationSearchValidator
 		// Unit
 		if ( ($_POST['unit'] !== 'miles') && ($_POST['unit'] !== 'kilometers') ){
 			throw new \Exception(__('Invalid unit.', 'wpsimplelocator'));
-			break;
 		}
 
 		if ( isset($_POST['allow_empty_address']) && $_POST['allow_empty_address'] == 'true' ) return;
@@ -18,13 +17,11 @@ class LocationSearchValidator
 		// Latitude & Longitude
 		if ( !is_numeric($_POST['latitude']) || !is_numeric($_POST['longitude']) ) {
 			throw new \Exception(__('The address could not be located at this time.', 'wpsimplelocator'));
-			break;
 		}
 
 		// Distance
 		if ( !ctype_digit($_POST['distance']) ) {
 			throw new \Exception(__('Please enter a valid distance.', 'wpsimplelocator'));
-			break;
 		}
 	}
 }

--- a/app/Services/Validation/NonceValidator.php
+++ b/app/Services/Validation/NonceValidator.php
@@ -14,7 +14,6 @@ class NonceValidator
 	{
 		if ( ! wp_verify_nonce( $submitted_nonce, $match_nonce ) ){
 			throw new \Exception(__('Incorrect Form Field', 'wpsimplelocator'));
-			break;
 		}
 	}
 


### PR DESCRIPTION
Break instructions is issued after throwing an exception on multiple place in the code. 
This behaviour is not more allowed in PHP7. This fix remove break instructions in such cases.